### PR TITLE
Add Dependabot config with 1-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling weekly Bundler updates with a 7-day cooldown on new releases (`default-days: 7`), so newly published gem versions wait a week before being proposed.

## Test plan
- [ ] Verify Dependabot picks up the config on next scheduled run.