### PR TITLE
Fix GitHub Pages build: untrack broken AGENTS.md and CLAUDE.md symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .sass-cache/
 _site/
 *.swp
+AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-/Users/etienne.vandelden/Developer/dotfiles/agents.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/_config.yml
+++ b/_config.yml
@@ -69,10 +69,6 @@ owner:
 
 theme: jekyll-theme-minimal
 
-exclude:
-  - AGENTS.md
-  - CLAUDE.md
-
 # Front matter defaults — auto-apply dnd_theme to all posts in _posts/dnd/
 defaults:
   - scope:


### PR DESCRIPTION
## Summary
- `AGENTS.md` and `CLAUDE.md` were committed as symlinks pointing to an absolute local path (`/Users/etienne.vandelden/Developer/dotfiles/agents.md`) that doesn't exist on GitHub's runner.
- Jekyll crashes when resolving symlinks before its `exclude` list can fire, breaking every Pages build since the files were added.
- Fix: untrack both files from git, add them to `.gitignore`, and remove the now-unnecessary `exclude` entries from `_config.yml`. The local symlinks remain in place so AI agents can still read them.

## Test plan
- [ ] Confirm the "pages build and deployment" Actions run on master succeeds after merge.
- [ ] Confirm site is live at https://etienne.vandelden.family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)