### PR TITLE
Mark Dark Sun Campaign Setting as owned in library

### DIFF
--- a/_data/books.yml
+++ b/_data/books.yml
@@ -466,7 +466,7 @@
 - cover: /img/library/4e-ds-hb-campaign.jpg
   title: Dark Sun Campaign Setting
   edition: 4e
-  status: wanted
+  status: owned
 
 - cover: /img/library/4e-ds-hb-creature.jpg
   title: Dark Sun Creature Catalog


### PR DESCRIPTION
## Summary
- Moves Dark Sun Campaign Setting from the Wanted section to the 4th Edition section by changing `status: wanted` → `status: owned` in `_data/books.yml`

## Test plan
- [ ] Visit the library page and confirm Dark Sun Campaign Setting appears in the 4e section
- [ ] Confirm it no longer appears in the Wanted section

🤖 Generated with [Claude Code](https://claude.com/claude-code)